### PR TITLE
fix: make the example app wait for spid-testenv2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     command: ["yarn", "dev"]
     networks:
       - spid-express-app
+    depends_on:
+      - spid-testenv2
 
   spid-testenv2:
     image: italia/spid-testenv2:latest


### PR DESCRIPTION
The example app uses spid-testenv2 and GETs its metadata at
start.

If spid-testenv2 is not ready yet, the example app would fail
to retrieve the metadata and treat xx_testenv2 as an unknown IdP
("Missing idpIssuer inside configuration").