### PR TITLE
Fixed check on validateIssuer

### DIFF
--- a/src/utils/saml.ts
+++ b/src/utils/saml.ts
@@ -643,7 +643,12 @@ const validateIssuer = (
         .getElementsByTagNameNS(SAML_NAMESPACE.ASSERTION, "Issuer")
         .item(0)
     )
-  ).chain(Issuer =>
+  ).chain(fromPredicate(
+    () => {
+      return fatherElement === fatherElement.getElementsByTagNameNS(SAML_NAMESPACE.ASSERTION, "Issuer").item(0)?.parentNode;
+    },
+    () => new Error("Issuer element must be present as direct child on "+fatherElement)
+  )).chain(Issuer =>
     NonEmptyString.decode(Issuer.textContent?.trim())
       .mapLeft(() => new Error("Issuer element must be not empty"))
       .chain(


### PR DESCRIPTION
This should fix test 28 failing in spid-test-sp:
getElementsByTagNameNS is getting any nested element starting from fatherElement. If tag Issuer was not present as direct child of Response, authentication was still successful because of the Issuer child on Assertion tag.